### PR TITLE
Link map with chart selection

### DIFF
--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -6,7 +6,7 @@ import {
 import { graphOptions } from '../utils/constants';
 import { formatYAxis, CustomTooltip } from '../utils/formatters';
 
-const DataChart = ({ data, selectedGraph }) => {
+const DataChart = ({ data, selectedGraph, onRangeSelect }) => {
   const [refAreaLeft, setRefAreaLeft] = useState('');
   const [refAreaRight, setRefAreaRight] = useState('');
   const [left, setLeft] = useState('dataMin');
@@ -49,6 +49,7 @@ const DataChart = ({ data, selectedGraph }) => {
     if (refAreaLeft === refAreaRight || refAreaRight === '') {
       setRefAreaLeft('');
       setRefAreaRight('');
+      if (onRangeSelect) onRangeSelect(null);
       return;
     }
 
@@ -63,6 +64,10 @@ const DataChart = ({ data, selectedGraph }) => {
     const [bottom, top] = getAxisYDomain(leftIndex, rightIndex, currentOption.y1, 1);
     setBottom(bottom);
     setTop(top);
+
+    if (onRangeSelect) {
+      onRangeSelect({ start: leftIndex, end: rightIndex });
+    }
   };
 
   const zoomOut = () => {
@@ -72,6 +77,7 @@ const DataChart = ({ data, selectedGraph }) => {
     setRight('dataMax');
     setTop('dataMax+1');
     setBottom('dataMin');
+    if (onRangeSelect) onRangeSelect(null);
   };
 
   useEffect(() => {

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -1,17 +1,25 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { MapContainer, TileLayer, Polyline } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 
 // 色のリスト（区間ごとに使用）
 const COLORS = ['blue', 'green', 'red', 'orange', 'purple', 'cyan'];
 
-const MapView = ({ segments }) => {
+const MapView = ({ segments, data, highlightRange }) => {
   if (!segments || segments.length === 0) {
     return <p>地図を表示するためのデータがありません。</p>;
   }
 
   // 最初の位置（地図の初期表示に使用）
   const position = [segments[0][0].gpsLat, segments[0][0].gpsLon];
+
+  const highlightPositions = useMemo(() => {
+    if (!highlightRange || !data || data.length === 0) return null;
+    const start = Math.max(0, highlightRange.start);
+    const end = Math.min(data.length - 1, highlightRange.end);
+    const slice = data.slice(start, end + 1);
+    return slice.map(coord => [coord.gpsLat, coord.gpsLon]);
+  }, [highlightRange, data]);
   
   return (
     <MapContainer center={position} zoom={13} style={{ height: '400px', width: '100%' }}>
@@ -26,6 +34,13 @@ const MapView = ({ segments }) => {
           color={COLORS[index % COLORS.length]} // 色を区間ごとに割り当て
         />
       ))}
+      {highlightPositions && (
+        <Polyline
+          positions={highlightPositions}
+          color="yellow"
+          weight={6}
+        />
+      )}
     </MapContainer>
   );
 };

--- a/src/components/RowingDataVisualization.js
+++ b/src/components/RowingDataVisualization.js
@@ -11,6 +11,7 @@ import MapView from './MapView';
 const RowingDataVisualization = () => {
   const [data, setData] = useState([]);
   const [segments, setSegments] = useState([]);
+  const [highlightRange, setHighlightRange] = useState(null);
   const [selectedFile, setSelectedFile] = useState('');
   const [availableFiles, setAvailableFiles] = useState([]);
   const [selectedGraph, setSelectedGraph] = useState('distance-speed');
@@ -64,6 +65,10 @@ const RowingDataVisualization = () => {
     setUseCalendar(!useCalendar);
   };
 
+  const handleRangeSelect = (range) => {
+    setHighlightRange(range);
+  };
+
   return (
     <div className="rowing-data-container">
       <h2 className="wakana-sc-title">WAKANA SC</h2>
@@ -106,11 +111,11 @@ const RowingDataVisualization = () => {
       ) : data.length > 0 ? (
         <>
           <div className="chart-container">
-            <DataChart data={data} selectedGraph={selectedGraph} />
+            <DataChart data={data} selectedGraph={selectedGraph} onRangeSelect={handleRangeSelect} />
           </div>
           <SessionInfo startTime={startTime} summary={sessionSummary} />
           <div className="map-container">
-            <MapView segments={segments} />
+            <MapView segments={segments} data={data} highlightRange={highlightRange} />
           </div>
         </>
       ) : (


### PR DESCRIPTION
## Summary
- update DataChart to report selected range
- connect range selection to MapView in RowingDataVisualization
- highlight selected chart range on the map

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413409e500832e96848fe4d991232e