### PR TITLE
Add user-select none to data-chart container

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,6 +100,10 @@ select, .file-select {
 .data-chart-container {
   width: 100%;
   min-width: auto; /* 600px から auto に変更 */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .chart-map-wrapper {


### PR DESCRIPTION
## Summary
- prevent text selection when dragging charts

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f0095af8832eb5be72062f704990