### PR TITLE
Fix highlight lost on brush

### DIFF
--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -72,7 +72,7 @@ const DataChart = ({ data, selectedGraph, onRangeSelect }) => {
     if (refAreaLeft === refAreaRight || refAreaRight === '') {
       setRefAreaLeft('');
       setRefAreaRight('');
-      if (onRangeSelect) onRangeSelect(null);
+      // ブラシ操作時はここで範囲をリセットしない
       return;
     }
 


### PR DESCRIPTION
## Summary
- prevent brush interactions from clearing the map highlight

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef7d4e70832e896ff891d6bcee4f