### PR TITLE
Enable GitHub Pages deployment on master push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and deploy
+        run: npm run deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ npm run build
 npm test
 ```
 
+### デプロイ
+
+`master` ブランチに push すると GitHub Actions がビルドを行い、GitHub Pages が自動更新されます。
+
 ## 使い方
 
 - `public/data` に CSV を追加し、`public/available_files.json` に登録すると選択肢として表示されます。


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and deploys the site whenever `master` is updated
- document automatic deployment in the README

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c5c45df0832e89670495bacabcc2