### PR TITLE
Fix GitHub Actions deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Configure git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
       - name: Build and deploy
         run: CI=false npm run deploy
         env:


### PR DESCRIPTION
## Summary
- configure git user info before gh-pages deploy so deployment succeeds

## Testing
- `npm ci` *(fails: ENOTFOUND, network access is disabled)*
- `npm test -- --watchAll=false` *(fails: react-app-rewired not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6860ca381cd0832eb02c6bbbefff68e5