### PR TITLE
Add previous/next file navigation buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 /* 基本スタイル */
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f0f2f5;
   margin: 0;
   padding: 0;
@@ -63,7 +63,8 @@ main {
   flex: 1;
 }
 
-select, .file-select {
+select,
+.file-select {
   width: 100%;
   padding: 0.5rem;
   border: 1px solid #d1d5db;
@@ -75,7 +76,9 @@ select, .file-select {
   margin-bottom: 1rem;
 }
 
-.selector-toggle button, .zoom-out-btn, .file-uploader button {
+.selector-toggle button,
+.zoom-out-btn,
+.file-uploader button {
   background-color: #4299e1;
   color: white;
   border: none;
@@ -86,7 +89,31 @@ select, .file-select {
   transition: background-color 0.3s ease;
 }
 
-.selector-toggle button:hover, .zoom-out-btn:hover, .file-uploader button:hover {
+.file-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.file-selector button {
+  background-color: #4299e1;
+  color: white;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.3s ease;
+}
+
+.file-selector button:disabled {
+  background-color: #a0aec0;
+  cursor: not-allowed;
+}
+
+.selector-toggle button:hover,
+.zoom-out-btn:hover,
+.file-uploader button:hover {
   background-color: #3182ce;
 }
 
@@ -158,11 +185,13 @@ select, .file-select {
 }
 
 /* セッション情報のスタイル */
-.session-info, .session-summary {
+.session-info,
+.session-summary {
   margin-top: 2rem;
 }
 
-.session-info h3, .session-summary h3 {
+.session-info h3,
+.session-summary h3 {
   font-size: 1.2rem;
   margin-bottom: 0.5rem;
   color: #2c5282;
@@ -179,7 +208,8 @@ table {
   border-collapse: collapse;
 }
 
-th, td {
+th,
+td {
   text-align: left;
   padding: 0.75rem;
   border-bottom: 1px solid #e5e7eb;
@@ -312,7 +342,7 @@ th {
 .hamburger-icon span {
   width: 2rem;
   height: 0.25rem;
-  background: #0D0C1D;
+  background: #0d0c1d;
   border-radius: 10px;
   transition: all 0.3s linear;
   position: relative;

--- a/src/components/FileSelector.js
+++ b/src/components/FileSelector.js
@@ -1,8 +1,29 @@
-import React from 'react';
+import React from "react";
 
 const FileSelector = ({ availableFiles, onFileSelect, selectedFile }) => {
+  const currentIndex = availableFiles.indexOf(selectedFile);
+
+  const handlePrev = () => {
+    if (currentIndex > 0) {
+      onFileSelect(availableFiles[currentIndex - 1]);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentIndex < availableFiles.length - 1) {
+      onFileSelect(availableFiles[currentIndex + 1]);
+    }
+  };
+
   return (
     <div className="file-selector">
+      <button
+        className="file-nav-btn"
+        onClick={handlePrev}
+        disabled={currentIndex <= 0}
+      >
+        &lt;
+      </button>
       <select
         value={selectedFile}
         onChange={(e) => onFileSelect(e.target.value)}
@@ -15,6 +36,15 @@ const FileSelector = ({ availableFiles, onFileSelect, selectedFile }) => {
           </option>
         ))}
       </select>
+      <button
+        className="file-nav-btn"
+        onClick={handleNext}
+        disabled={
+          currentIndex === -1 || currentIndex >= availableFiles.length - 1
+        }
+      >
+        &gt;
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add file navigation buttons to `FileSelector`
- style new buttons in `App.css`

## Testing
- `npm test -- --watchAll=false` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865009ece90832e8dcecfe34cf7952c