### PR TITLE
Implement stroke renumbering in segment exports

### DIFF
--- a/src/components/CSVSegmentProcessor.js
+++ b/src/components/CSVSegmentProcessor.js
@@ -68,8 +68,18 @@ const CSVSegmentProcessor = () => {
     const dataHeaderLine = lines[perStrokeIndex + 2] || "";
     const dataUnitsLine  = lines[perStrokeIndex + 3] || "";
 
-    // ④ 新たなデータ行：指定したStrokes範囲の行をそのまま抽出
-    const newDataRows = originalData.slice(startIndex, endIndex + 1);
+    // ④ 新たなデータ行：指定したStrokes範囲を抽出し、ストローク番号を振り直す
+    const headerColumns = dataHeaderLine.split(',').map(h => h.trim());
+    const strokeColIndex = headerColumns.indexOf('Total Strokes');
+    const newDataRows = originalData.slice(startIndex, endIndex + 1).map((line, idx) => {
+      if (strokeColIndex === -1) return line;
+      const cols = line.split(',');
+      // strokeColIndex が範囲外の場合はそのまま返す
+      if (cols.length > strokeColIndex) {
+        cols[strokeColIndex] = (idx + 1).toString();
+      }
+      return cols.join(',');
+    });
     
     // ⑤ Session Summary セクションの再構築
     // 以下は固定フォーマットとし、元のサマリ値行以降は出力しない


### PR DESCRIPTION
## Summary
- renumber strokes when exporting a stroke range in `CSVSegmentProcessor`

## Testing
- `npm test` *(fails: react-app-rewired not found)*


------
https://chatgpt.com/codex/tasks/task_e_6888c708f9cc832eae708bc0353fed24